### PR TITLE
fixed: do not limit the number of clones in the table

### DIFF
--- a/Source/PlantGenetics/PottingBench/UI/Window_PottingBench.cs
+++ b/Source/PlantGenetics/PottingBench/UI/Window_PottingBench.cs
@@ -106,7 +106,6 @@ namespace PlantGenetics
                 traitRect.y += 20f;
                 actionRect.y += 20f;
                 removeRect.y += 20f;
-                if (nameRect.y > InitialSize.y) break;
                 var fullRect = new Rect(nameRect.x - 4f, nameRect.y, nameRect.width + traitRect.width + actionRect.width,
                     20f);
                 if (highlight) Widgets.DrawHighlight(fullRect);


### PR DESCRIPTION
After adding ScrollView this line of code does not allow displaying more than 37 records in the table

A removed it